### PR TITLE
Removed hasTag function due to Error in Symfony 4.3.*

### DIFF
--- a/Entity/AbstractTaggable.php
+++ b/Entity/AbstractTaggable.php
@@ -39,11 +39,6 @@ abstract class AbstractTaggable implements TaggableInterface
         $this->tags->removeElement($tag);
     }
 
-    public function hasTag(TagInterface $tag): bool
-    {
-        return $this->tags->contains($tag);
-    }
-
     public function getTags(): iterable
     {
         return $this->tags;

--- a/Listener/TagSubscriber.php
+++ b/Listener/TagSubscriber.php
@@ -112,7 +112,7 @@ class TagSubscriber implements EventSubscriber
                 // see http://docs.doctrine-project.org/projects/doctrine-orm/en/latest/reference/events.html#onflush
                 $this->uow->computeChangeSet($tagClassMetadata, $tag);
             }
-            if (!$entity->hasTag($tag)) {
+            if (!$entity->getTags()->contains($tag)) {
                 // add tag only if not already added
                 $entity->addTag($tag);
             }

--- a/Listener/TagSubscriber.php
+++ b/Listener/TagSubscriber.php
@@ -112,7 +112,7 @@ class TagSubscriber implements EventSubscriber
                 // see http://docs.doctrine-project.org/projects/doctrine-orm/en/latest/reference/events.html#onflush
                 $this->uow->computeChangeSet($tagClassMetadata, $tag);
             }
-            if (!$entity->getTags()->contains($tag)) {
+            if (!in_array($tag, $entity->getTags())) {
                 // add tag only if not already added
                 $entity->addTag($tag);
             }

--- a/Resources/doc/index.md
+++ b/Resources/doc/index.md
@@ -1,5 +1,4 @@
-BeelabTagBundle Documentation
-=============================
+# BeelabTagBundle Documentation
 
 ## Installation
 
@@ -31,6 +30,7 @@ public function registerBundles()
     ];
 }
 ```
+
 See also [Other bundles](#4-other-bundles) for a note about registering order.
 
 ### 2. Configuration
@@ -97,8 +97,8 @@ Following configuration is added by recipe:
 # config/packages/beelab_tag.yaml
 
 beelab_tag:
-    tag_class: App\Entity\Tag
-    purge: false
+  tag_class: App\Entity\Tag
+  purge: false
 ```
 
 > **Warning**: the `purge` option is not mandatory and defaults to `false`. You should use this
@@ -152,11 +152,6 @@ class Article implements TaggableInterface
     public function removeTag(TagInterface $tag): void
     {
         $this->tags->removeElement($tag);
-    }
-
-    public function hasTag(TagInterface $tag): bool
-    {
-        return $this->tags->contains($tag);
     }
 
     public function getTags(): iterable

--- a/Tag/TaggableInterface.php
+++ b/Tag/TaggableInterface.php
@@ -10,7 +10,5 @@ interface TaggableInterface
 
     public function getTags(): iterable;
 
-    public function hasTag(TagInterface $tag): bool;
-
     public function removeTag(TagInterface $tag): void;
 }

--- a/Test/TaggableStub.php
+++ b/Test/TaggableStub.php
@@ -24,11 +24,6 @@ class TaggableStub implements TaggableInterface
         return [new TagStub()];
     }
 
-    public function hasTag(TagInterface $tag): bool
-    {
-        return true;
-    }
-
     public function removeTag(TagInterface $tag): void
     {
     }

--- a/Tests/Entity/AbstractTaggableTest.php
+++ b/Tests/Entity/AbstractTaggableTest.php
@@ -10,21 +10,13 @@ use PHPUnit\Framework\TestCase;
  */
 final class AbstractTaggableTest extends TestCase
 {
-    public function testHasTag(): void
-    {
-        $tag = $this->getMockBuilder('Beelab\TagBundle\Tag\TagInterface')->getMock();
-        $entity = new Entity();
-        $entity->addTag($tag);
-        $this->assertTrue($entity->hasTag($tag));
-    }
-
     public function testRemoveTag(): void
     {
         $tag = $this->getMockBuilder('Beelab\TagBundle\Tag\TagInterface')->getMock();
         $entity = new Entity();
         $entity->addTag($tag);
         $entity->removeTag($tag);
-        $this->assertFalse($entity->hasTag($tag));
+        $this->assertFalse($entity->getTags()->contains($tag));
     }
 
     public function testGetTags(): void

--- a/Tests/Entity/AbstractTaggableTest.php
+++ b/Tests/Entity/AbstractTaggableTest.php
@@ -15,7 +15,7 @@ final class AbstractTaggableTest extends TestCase
         $tag = $this->getMockBuilder('Beelab\TagBundle\Tag\TagInterface')->getMock();
         $entity = new Entity();
         $entity->addTag($tag);
-        $this->assertTrue(in_array($tag, $entity->getTags()));
+        $this->assertTrue($entity->getTags()->contains($tag));
     }
 
     public function testRemoveTag(): void
@@ -24,7 +24,7 @@ final class AbstractTaggableTest extends TestCase
         $entity = new Entity();
         $entity->addTag($tag);
         $entity->removeTag($tag);
-        $this->assertFalse(in_array($tag, $entity->getTags()));
+        $this->assertFalse($entity->getTags()->contains($tag));
     }
 
     public function testGetTags(): void

--- a/Tests/Entity/AbstractTaggableTest.php
+++ b/Tests/Entity/AbstractTaggableTest.php
@@ -15,7 +15,7 @@ final class AbstractTaggableTest extends TestCase
         $tag = $this->getMockBuilder('Beelab\TagBundle\Tag\TagInterface')->getMock();
         $entity = new Entity();
         $entity->addTag($tag);
-        $this->assertTrue($entity->getTags()->contains($tag));
+        $this->assertTrue(in_array($tag, $entity->getTags()));
     }
 
     public function testRemoveTag(): void
@@ -24,7 +24,7 @@ final class AbstractTaggableTest extends TestCase
         $entity = new Entity();
         $entity->addTag($tag);
         $entity->removeTag($tag);
-        $this->assertFalse($entity->getTags()->contains($tag));
+        $this->assertFalse(in_array($tag, $entity->getTags()));
     }
 
     public function testGetTags(): void

--- a/Tests/Entity/AbstractTaggableTest.php
+++ b/Tests/Entity/AbstractTaggableTest.php
@@ -10,6 +10,14 @@ use PHPUnit\Framework\TestCase;
  */
 final class AbstractTaggableTest extends TestCase
 {
+    public function testAddTag(): void
+    {
+        $tag = $this->getMockBuilder('Beelab\TagBundle\Tag\TagInterface')->getMock();
+        $entity = new Entity();
+        $entity->addTag($tag);
+        $this->assertTrue($entity->getTags()->contains($tag));
+    }
+
     public function testRemoveTag(): void
     {
         $tag = $this->getMockBuilder('Beelab\TagBundle\Tag\TagInterface')->getMock();


### PR DESCRIPTION
When using Symfony 4.3.* the "hasTag" function causes the Error: Property "tag" does not exist in class "App\Entity\SomeEntity". Therefore I propose removing it.

This is my first PR so any feedback regarding my description or anything else would be greatly appreciated!